### PR TITLE
upgrade-dependencies-to-5.x

### DIFF
--- a/base.scss
+++ b/base.scss
@@ -18,7 +18,7 @@ $_maximum: 20px;
 $_minimum: 2px;
 $_padding_ratio: 0.75;
 
-// https://github.com/alphagov/govuk-frontend/blob/main/src/govuk/components/input/_index.scss#L17
+// https://github.com/alphagov/govuk-frontend/blob/48d15230ba99695912b2120f77703383f1b7ba0f/packages/govuk-frontend/src/govuk/components/input/_index.scss#L13
 $_default-padding: govuk-spacing(1);
 $_padding: math.clamp($_default-padding, ($_padding_ratio * $govuk-frontend-rounded), $_maximum);
 $_border-radius: math.clamp($_minimum, $govuk-frontend-rounded, $_maximum);

--- a/index.njk
+++ b/index.njk
@@ -1,34 +1,34 @@
-{% extends "node_modules/govuk-frontend/govuk/template.njk" %}
+{% extends "node_modules/govuk-frontend/dist/govuk/template.njk" %}
 
-{% from "node_modules/govuk-frontend/govuk/components/accordion/macro.njk"           import govukAccordion %}
-{% from "node_modules/govuk-frontend/govuk/components/back-link/macro.njk"           import govukBackLink %}
-{% from "node_modules/govuk-frontend/govuk/components/breadcrumbs/macro.njk"         import govukBreadcrumbs %}
-{% from "node_modules/govuk-frontend/govuk/components/button/macro.njk"              import govukButton %}
-{% from "node_modules/govuk-frontend/govuk/components/character-count/macro.njk"     import govukCharacterCount %}
-{% from "node_modules/govuk-frontend/govuk/components/checkboxes/macro.njk"          import govukCheckboxes %}
-{% from "node_modules/govuk-frontend/govuk/components/cookie-banner/macro.njk"       import govukCookieBanner %}
-{% from "node_modules/govuk-frontend/govuk/components/date-input/macro.njk"          import govukDateInput %}
-{% from "node_modules/govuk-frontend/govuk/components/details/macro.njk"             import govukDetails %}
-{% from "node_modules/govuk-frontend/govuk/components/error-message/macro.njk"       import govukErrorMessage %}
-{% from "node_modules/govuk-frontend/govuk/components/error-summary/macro.njk"       import govukErrorSummary %}
-{% from "node_modules/govuk-frontend/govuk/components/fieldset/macro.njk"            import govukFieldset %}
-{% from "node_modules/govuk-frontend/govuk/components/file-upload/macro.njk"         import govukFileUpload %}
-{% from "node_modules/govuk-frontend/govuk/components/input/macro.njk"               import govukInput %}
-{% from "node_modules/govuk-frontend/govuk/components/inset-text/macro.njk"          import govukInsetText %}
-{% from "node_modules/govuk-frontend/govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
-{% from "node_modules/govuk-frontend/govuk/components/pagination/macro.njk"          import govukPagination %}
-{% from "node_modules/govuk-frontend/govuk/components/panel/macro.njk"               import govukPanel %}
-{% from "node_modules/govuk-frontend/govuk/components/phase-banner/macro.njk"        import govukPhaseBanner %}
-{% from "node_modules/govuk-frontend/govuk/components/radios/macro.njk"              import govukRadios %}
-{% from "node_modules/govuk-frontend/govuk/components/select/macro.njk"              import govukSelect %}
-{% from "node_modules/govuk-frontend/govuk/components/skip-link/macro.njk"           import govukSkipLink %}
-{% from "node_modules/govuk-frontend/govuk/components/summary-list/macro.njk"        import govukSummaryList %}
-{% from "node_modules/govuk-frontend/govuk/components/table/macro.njk"               import govukTable %}
-{% from "node_modules/govuk-frontend/govuk/components/tabs/macro.njk"                import govukTabs %}
-{% from "node_modules/govuk-frontend/govuk/components/tag/macro.njk"                 import govukTag %}
-{% from "node_modules/govuk-frontend/govuk/components/textarea/macro.njk"            import govukTextarea %}
-{% from "node_modules/govuk-frontend/govuk/components/warning-text/macro.njk"        import govukWarningText %}
-{% from "node_modules/govuk-frontend/govuk/components/summary-list/macro.njk"        import govukSummaryList %}
+{% from "node_modules/govuk-frontend/dist/govuk/components/accordion/macro.njk"           import govukAccordion %}
+{% from "node_modules/govuk-frontend/dist/govuk/components/back-link/macro.njk"           import govukBackLink %}
+{% from "node_modules/govuk-frontend/dist/govuk/components/breadcrumbs/macro.njk"         import govukBreadcrumbs %}
+{% from "node_modules/govuk-frontend/dist/govuk/components/button/macro.njk"              import govukButton %}
+{% from "node_modules/govuk-frontend/dist/govuk/components/character-count/macro.njk"     import govukCharacterCount %}
+{% from "node_modules/govuk-frontend/dist/govuk/components/checkboxes/macro.njk"          import govukCheckboxes %}
+{% from "node_modules/govuk-frontend/dist/govuk/components/cookie-banner/macro.njk"       import govukCookieBanner %}
+{% from "node_modules/govuk-frontend/dist/govuk/components/date-input/macro.njk"          import govukDateInput %}
+{% from "node_modules/govuk-frontend/dist/govuk/components/details/macro.njk"             import govukDetails %}
+{% from "node_modules/govuk-frontend/dist/govuk/components/error-message/macro.njk"       import govukErrorMessage %}
+{% from "node_modules/govuk-frontend/dist/govuk/components/error-summary/macro.njk"       import govukErrorSummary %}
+{% from "node_modules/govuk-frontend/dist/govuk/components/fieldset/macro.njk"            import govukFieldset %}
+{% from "node_modules/govuk-frontend/dist/govuk/components/file-upload/macro.njk"         import govukFileUpload %}
+{% from "node_modules/govuk-frontend/dist/govuk/components/input/macro.njk"               import govukInput %}
+{% from "node_modules/govuk-frontend/dist/govuk/components/inset-text/macro.njk"          import govukInsetText %}
+{% from "node_modules/govuk-frontend/dist/govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+{% from "node_modules/govuk-frontend/dist/govuk/components/pagination/macro.njk"          import govukPagination %}
+{% from "node_modules/govuk-frontend/dist/govuk/components/panel/macro.njk"               import govukPanel %}
+{% from "node_modules/govuk-frontend/dist/govuk/components/phase-banner/macro.njk"        import govukPhaseBanner %}
+{% from "node_modules/govuk-frontend/dist/govuk/components/radios/macro.njk"              import govukRadios %}
+{% from "node_modules/govuk-frontend/dist/govuk/components/select/macro.njk"              import govukSelect %}
+{% from "node_modules/govuk-frontend/dist/govuk/components/skip-link/macro.njk"           import govukSkipLink %}
+{% from "node_modules/govuk-frontend/dist/govuk/components/summary-list/macro.njk"        import govukSummaryList %}
+{% from "node_modules/govuk-frontend/dist/govuk/components/table/macro.njk"               import govukTable %}
+{% from "node_modules/govuk-frontend/dist/govuk/components/tabs/macro.njk"                import govukTabs %}
+{% from "node_modules/govuk-frontend/dist/govuk/components/tag/macro.njk"                 import govukTag %}
+{% from "node_modules/govuk-frontend/dist/govuk/components/textarea/macro.njk"            import govukTextarea %}
+{% from "node_modules/govuk-frontend/dist/govuk/components/warning-text/macro.njk"        import govukWarningText %}
+{% from "node_modules/govuk-frontend/dist/govuk/components/summary-list/macro.njk"        import govukSummaryList %}
 
 {% block head %}
     {{ super() }}
@@ -43,7 +43,7 @@
     <h1 class="govuk-heading-xl">GOV.UK Frontend Rounded</h1>
     <p class="govuk-body">Rounded corners for GOV.UK Frontend, useful when branding the GOV.UK Design System.</p>
     <p class="govuk-body">This example shows corners of 10px in radius.</p>
-    <p class="govuk-body">See the <a href="https://github.com/NickColley/govuk-frontend-rounded#install">README for installation instructions</a>.</p>
+    <p class="govuk-body">See the <a class="govuk-link" href="https://github.com/NickColley/govuk-frontend-rounded#install">README for installation instructions</a>.</p>
     <h2 class="govuk-heading-l">Button</h2>
     {{ govukButton({
         text: "Save and continue"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,23 @@
 {
   "name": "govuk-frontend-rounded",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "govuk-frontend-rounded",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "devDependencies": {
         "@11ty/eleventy": "1.0.1",
         "eleventy-plugin-dart-sass": "1.0.3",
-        "govuk-frontend": "^4.7.0"
+        "govuk-frontend": "^5.2.0"
       },
       "engines": {
-        "node": "~16.14.2"
+        "node": ">=16.14.2"
       },
       "peerDependencies": {
-        "govuk-frontend": "4.7.x"
+        "govuk-frontend": "5.x"
       }
     },
     "node_modules/@11ty/dependency-tree": {
@@ -1346,9 +1346,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.7.0.tgz",
-      "integrity": "sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.2.0.tgz",
+      "integrity": "sha512-beD3wztHpkKz6JUpPwnwop1ejb4rTFMPLCutKLCIDmUS4BPpW59ggVUfctsRqHd2Zjw9wxljdRdeIJ8AZFyyTw==",
       "dev": true,
       "engines": {
         "node": ">= 4.2.0"

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
   "devDependencies": {
     "@11ty/eleventy": "1.0.1",
     "eleventy-plugin-dart-sass": "1.0.3",
-    "govuk-frontend": "^4.7.0"
+    "govuk-frontend": "^5.2.0"
   },
   "peerDependencies": {
-    "govuk-frontend": "4.x"
+    "govuk-frontend": "5.x"
   }
 }

--- a/page.scss
+++ b/page.scss
@@ -1,4 +1,4 @@
-@import "node_modules/govuk-frontend/govuk/base.scss";
+@import "node_modules/govuk-frontend/dist/govuk/base";
 
 // We're not using the GOV.UK Footer so set 
 // the entire page to the body background colour.
@@ -7,7 +7,7 @@ $govuk-canvas-background-colour: $govuk-body-background-colour;
 // We can't use the GDS Transport font on non-GOV.UK pages.
 $govuk-font-family: Helvetica, Arial, sans-serif;
 
-@import "node_modules/govuk-frontend/govuk/all.scss";
+@import "node_modules/govuk-frontend/dist/govuk/all";
 
 $govuk-frontend-rounded: 10px;
 


### PR DESCRIPTION
Support and require the latest version, will be released as a breaking change as import paths have changed 